### PR TITLE
Handle errors in theme SCSS file

### DIFF
--- a/src/antdLessLoader.js
+++ b/src/antdLessLoader.js
@@ -8,7 +8,7 @@ import { getScssThemePath } from './loaderUtils';
 /**
  * Modify less-loader's options with variable overrides extracted from the SCSS theme.
  * @param {Object} options - Options for less-loader.
- * @return {Objects} Options modified to include theme variables in the modifyVars property.
+ * @return {Object} Options modified to include theme variables in the modifyVars property.
  */
 export const overloadLessLoaderOptions = (options) => {
   const scssThemePath = getScssThemePath(options);

--- a/src/antdLessLoader.js
+++ b/src/antdLessLoader.js
@@ -37,9 +37,15 @@ export default function antdLessLoader(...args) {
   const options = getOptions(loaderContext);
 
   const newLoaderContext = { ...loaderContext };
-  const newOptions = overloadLessLoaderOptions(options);
-  delete newOptions.scssThemePath;
-  newLoaderContext.query = newOptions;
+  try {
+    const newOptions = overloadLessLoaderOptions(options);
+    delete newOptions.scssThemePath;
+    newLoaderContext.query = newOptions;
+  } catch (error) {
+    // Remove unhelpful stack from error.
+    error.stack = undefined; // eslint-disable-line no-param-reassign
+    throw error;
+  }
 
   const scssThemePath = getScssThemePath(options);
   newLoaderContext.addDependency(scssThemePath);

--- a/src/antdSassLoader.js
+++ b/src/antdSassLoader.js
@@ -13,6 +13,7 @@ import {
 /**
  * Utility returning a node-sass importer that provides access to all of antd's theme variables.
  * @param {string} themeScssPath - Path to SCSS file containing Ant Design theme variables.
+ * @param {string} contents - The compiled content of the SCSS file at themeScssPath.
  * @returns {function} Importer that provides access to all compiled Ant Design theme variables
  *   when importing the theme file at themeScssPath.
  */

--- a/src/antdSassLoader.js
+++ b/src/antdSassLoader.js
@@ -84,5 +84,9 @@ export default function antdSassLoader(...args) {
 
       return sassLoader.call(newLoaderContext, ...args);
     })
-    .catch(error => callback(error));
+    .catch((error) => {
+      // Remove unhelpful stack from error.
+      error.stack = undefined; // eslint-disable-line no-param-reassign
+      callback(error);
+    });
 }

--- a/src/antdSassLoader.js
+++ b/src/antdSassLoader.js
@@ -16,7 +16,7 @@ import {
  * @returns {function} Importer that provides access to all compiled Ant Design theme variables
  *   when importing the theme file at themeScssPath.
  */
-export const themeImporter = themeScssPath => (url, previousResolve, done) => {
+export const themeImporter = (themeScssPath, contents) => (url, previousResolve, done) => {
   const request = urlToRequest(url);
   const pathsToTry = importsToResolve(request);
 
@@ -24,9 +24,7 @@ export const themeImporter = themeScssPath => (url, previousResolve, done) => {
   for (let i = 0; i < pathsToTry.length; i += 1) {
     const potentialResolve = pathsToTry[i];
     if (path.resolve(baseDirectory, potentialResolve) === themeScssPath) {
-      compileThemeVariables(themeScssPath)
-        .then(contents => done({ contents }))
-        .catch(() => done());
+      done({ contents });
       return;
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,7 +43,12 @@ export const extractLessVariables = (lessEntryPath, variableOverrides = {}) => {
  * @return {Object} Object of the form { '@variable': 'value' }.
  */
 export const loadScssThemeAsLess = (themeScssPath) => {
-  const rawTheme = scssToJson(themeScssPath);
+  let rawTheme;
+  try {
+    rawTheme = scssToJson(themeScssPath);
+  } catch (error) {
+    throw new Error(`Could not compile "${themeScssPath}" for variable extraction.`);
+  }
   const theme = {};
   Object.keys(rawTheme).forEach((sassVariableName) => {
     const lessVariableName = sassVariableName.replace(/^\$/, '@');

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,7 +77,5 @@ export const compileThemeVariables = (themeScssPath) => {
       Object.entries(variables)
         .map(([name, value]) => `$${name}: ${value};\n`)
         .join('')
-    )).catch((error) => {
-      throw error;
-    });
+    ));
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,10 @@ export const loadScssThemeAsLess = (themeScssPath) => {
   try {
     rawTheme = scssToJson(themeScssPath);
   } catch (error) {
-    throw new Error(`Could not compile "${themeScssPath}" for variable extraction.`);
+    throw new Error(
+      `Could not compile the SCSS theme file "${themeScssPath}" for the purpose of variable ` +
+      'extraction. This is likely because it contains a Sass error.',
+    );
   }
   const theme = {};
   Object.keys(rawTheme).forEach((sassVariableName) => {


### PR DESCRIPTION
- Load the theme SCSS file's contents before making custom importer.
- Adapt sass-loader wrapper to async because of this.
- Clean up error messages and stacks before re-throwing.

Closes #26
