### PR TITLE
Some webpack versions have fileDependencies as Set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,16 @@ class AntdScssThemePlugin {
     const afterEmit = (compilation, callback) => {
       // Watch the theme file for changes.
       const theme = AntdScssThemePlugin.SCSS_THEME_PATH;
-      if (compilation.fileDependencies && !compilation.fileDependencies.includes(theme)) {
+      if (
+        Array.isArray(compilation.fileDependencies)
+        && !compilation.fileDependencies.includes(theme)
+      ) {
         compilation.fileDependencies.push(theme);
+      } else if (
+        compilation.fileDependencies instanceof Set
+        && !compilation.fileDependencies.has(theme)
+      ) {
+        compilation.fileDependencies.add(theme);
       }
       callback();
     };


### PR DESCRIPTION
Handle newer versions of webpack where fileDependencies is passed as a Set instead of an Array.

All credits to @RobinRadic.

Should fix #33.